### PR TITLE
Add clean strategy to reduce log files number

### DIFF
--- a/library/src/main/java/com/elvishew/xlog/internal/DefaultsFactory.java
+++ b/library/src/main/java/com/elvishew/xlog/internal/DefaultsFactory.java
@@ -40,6 +40,8 @@ import com.elvishew.xlog.printer.Printer;
 import com.elvishew.xlog.printer.file.FilePrinter;
 import com.elvishew.xlog.printer.file.backup.BackupStrategy;
 import com.elvishew.xlog.printer.file.backup.FileSizeBackupStrategy;
+import com.elvishew.xlog.printer.file.clean.CleanStrategy;
+import com.elvishew.xlog.printer.file.clean.TimeCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.ChangelessFileNameGenerator;
 import com.elvishew.xlog.printer.file.naming.FileNameGenerator;
 
@@ -55,6 +57,8 @@ public class DefaultsFactory {
   private static final String DEFAULT_LOG_FILE_NAME = "log";
 
   private static final long DEFAULT_LOG_FILE_MAX_SIZE = 1024 * 1024; // 1M bytes;
+
+  private static final long DEFAULT_LOG_FILE_MAX_TIME = 60 * 60 * 24 * 1000 * 2; // two days;
 
   private static final Map<Class<?>, ObjectFormatter<?>> BUILTIN_OBJECT_FORMATTERS;
 
@@ -133,6 +137,13 @@ public class DefaultsFactory {
    */
   public static BackupStrategy createBackupStrategy() {
     return new FileSizeBackupStrategy(DEFAULT_LOG_FILE_MAX_SIZE);
+  }
+
+  /**
+   * Create the default clean strategy for {@link FilePrinter}.
+   */
+  public static CleanStrategy createCleanStrategy() {
+    return new TimeCleanStrategy(DEFAULT_LOG_FILE_MAX_TIME);
   }
 
   /**

--- a/library/src/main/java/com/elvishew/xlog/internal/DefaultsFactory.java
+++ b/library/src/main/java/com/elvishew/xlog/internal/DefaultsFactory.java
@@ -41,6 +41,7 @@ import com.elvishew.xlog.printer.file.FilePrinter;
 import com.elvishew.xlog.printer.file.backup.BackupStrategy;
 import com.elvishew.xlog.printer.file.backup.FileSizeBackupStrategy;
 import com.elvishew.xlog.printer.file.clean.CleanStrategy;
+import com.elvishew.xlog.printer.file.clean.NeverCleanStrategy;
 import com.elvishew.xlog.printer.file.clean.TimeCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.ChangelessFileNameGenerator;
 import com.elvishew.xlog.printer.file.naming.FileNameGenerator;
@@ -143,7 +144,7 @@ public class DefaultsFactory {
    * Create the default clean strategy for {@link FilePrinter}.
    */
   public static CleanStrategy createCleanStrategy() {
-    return new TimeCleanStrategy(DEFAULT_LOG_FILE_MAX_TIME);
+    return new NeverCleanStrategy();
   }
 
   /**

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/CleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/CleanStrategy.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 Elvis Hew
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.elvishew.xlog.printer.file.clean;
 
 import java.io.File;

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/CleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/CleanStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 Elvis Hew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.elvishew.xlog.printer.file.clean;
+
+import java.io.File;
+
+/**
+ * Decide whether the log file should be clean.
+ */
+public interface CleanStrategy {
+
+  /**
+   * Whether we should clean a specified log file.
+   *
+   * @param file the log file
+   * @return true is we should clean the log file
+   */
+  boolean shouldClean(File file);
+}

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/NeverCleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/NeverCleanStrategy.java
@@ -1,0 +1,14 @@
+package com.elvishew.xlog.printer.file.clean;
+
+import java.io.File;
+
+/**
+ * Never Limit the file life.
+ */
+public class NeverCleanStrategy implements CleanStrategy {
+
+  @Override
+  public boolean shouldClean(File file) {
+    return false;
+  }
+}

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/TimeCleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/TimeCleanStrategy.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 Elvis Hew
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.elvishew.xlog.printer.file.clean;
 
 import java.io.File;

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/TimeCleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/TimeCleanStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Elvis Hew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.elvishew.xlog.printer.file.clean;
+
+import java.io.File;
+
+/**
+ * Limit the file life of a max time.
+ */
+public class TimeCleanStrategy implements CleanStrategy {
+
+  private long maxTimeMillis;
+
+  /**
+   * Constructor.
+   *
+   * @param maxTimeMillis the max time the file can keep
+   */
+  public TimeCleanStrategy(long maxTimeMillis) {
+    this.maxTimeMillis = maxTimeMillis;
+  }
+
+  @Override
+  public boolean shouldClean(File file) {
+    long currentTimeMillis = System.currentTimeMillis();
+    long fileTimeMillis = file.lastModified();
+    return (Math.abs(currentTimeMillis - fileTimeMillis) > maxTimeMillis);
+  }
+}

--- a/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
+++ b/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
@@ -27,6 +27,7 @@ import com.elvishew.xlog.interceptor.BlacklistTagsFilterInterceptor;
 import com.elvishew.xlog.printer.AndroidPrinter;
 import com.elvishew.xlog.printer.Printer;
 import com.elvishew.xlog.printer.file.FilePrinter;
+import com.elvishew.xlog.printer.file.clean.NeverCleanStrategy;
 import com.elvishew.xlog.printer.file.clean.TimeCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.DateFileNameGenerator;
 
@@ -35,8 +36,6 @@ import java.io.File;
 public class XLogSampleApplication extends Application {
 
   public static Printer globalFilePrinter;
-
-  private static final long MAX_TIME = 60 * 60 * 24 * 1000 * 2; // two days
 
   @Override
   public void onCreate() {
@@ -76,7 +75,7 @@ public class XLogSampleApplication extends Application {
         .Builder(new File(Environment.getExternalStorageDirectory(), "xlogsample").getPath())       // Specify the path to save log file
         .fileNameGenerator(new DateFileNameGenerator())        // Default: ChangelessFileNameGenerator("log")
         // .backupStrategy(new MyBackupStrategy())             // Default: FileSizeBackupStrategy(1024 * 1024)
-        .cleanStrategy(new TimeCleanStrategy(MAX_TIME))        // Default: TimeCleanStrategy(MAX_TIME)
+        .cleanStrategy(new NeverCleanStrategy())               // Default: NeverCleanStrategy()
         .logFlattener(new ClassicFlattener())                  // Default: DefaultFlattener
         .build();
 

--- a/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
+++ b/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
@@ -27,6 +27,7 @@ import com.elvishew.xlog.interceptor.BlacklistTagsFilterInterceptor;
 import com.elvishew.xlog.printer.AndroidPrinter;
 import com.elvishew.xlog.printer.Printer;
 import com.elvishew.xlog.printer.file.FilePrinter;
+import com.elvishew.xlog.printer.file.clean.TimeCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.DateFileNameGenerator;
 
 import java.io.File;
@@ -34,6 +35,8 @@ import java.io.File;
 public class XLogSampleApplication extends Application {
 
   public static Printer globalFilePrinter;
+
+  private static final long MAX_TIME = 60 * 60 * 24 * 1000 * 2; // two days
 
   @Override
   public void onCreate() {
@@ -73,8 +76,10 @@ public class XLogSampleApplication extends Application {
         .Builder(new File(Environment.getExternalStorageDirectory(), "xlogsample").getPath())       // Specify the path to save log file
         .fileNameGenerator(new DateFileNameGenerator())        // Default: ChangelessFileNameGenerator("log")
         // .backupStrategy(new MyBackupStrategy())             // Default: FileSizeBackupStrategy(1024 * 1024)
+        .cleanStrategy(new TimeCleanStrategy(MAX_TIME))        // Default: TimeCleanStrategy(MAX_TIME)
         .logFlattener(new ClassicFlattener())                  // Default: DefaultFlattener
         .build();
+
 
     XLog.init(                                                 // Initialize XLog
         config,                                                // Specify the log configuration, if not specified, will use new LogConfiguration.Builder().build()


### PR DESCRIPTION
When we chose DateFileNameGenerator, the files in log folder would be always increase day by day, so may be we need auto clean the old file feature to reduce the log files size in mobile.