### PR TITLE
Add clean strategy to reduce log files number

### DIFF
--- a/library/src/main/java/com/elvishew/xlog/internal/DefaultsFactory.java
+++ b/library/src/main/java/com/elvishew/xlog/internal/DefaultsFactory.java
@@ -40,6 +40,8 @@ import com.elvishew.xlog.printer.Printer;
 import com.elvishew.xlog.printer.file.FilePrinter;
 import com.elvishew.xlog.printer.file.backup.BackupStrategy;
 import com.elvishew.xlog.printer.file.backup.FileSizeBackupStrategy;
+import com.elvishew.xlog.printer.file.clean.CleanStrategy;
+import com.elvishew.xlog.printer.file.clean.NeverCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.ChangelessFileNameGenerator;
 import com.elvishew.xlog.printer.file.naming.FileNameGenerator;
 
@@ -133,6 +135,13 @@ public class DefaultsFactory {
    */
   public static BackupStrategy createBackupStrategy() {
     return new FileSizeBackupStrategy(DEFAULT_LOG_FILE_MAX_SIZE);
+  }
+
+  /**
+   * Create the default clean strategy for {@link FilePrinter}.
+   */
+  public static CleanStrategy createCleanStrategy() {
+    return new NeverCleanStrategy();
   }
 
   /**

--- a/library/src/main/java/com/elvishew/xlog/printer/file/FilePrinter.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/FilePrinter.java
@@ -114,7 +114,7 @@ public class FilePrinter implements Printer {
   /**
    * Do the real job of writing log to file.
    */
-  void doPrintln(int logLevel, String tag, String msg) {
+  private void doPrintln(int logLevel, String tag, String msg) {
     String lastFileName = writer.getLastFileName();
     if (lastFileName == null || fileNameGenerator.isFileNameChangeable()) {
       String newFileName = fileNameGenerator.generateFileName(logLevel, System.currentTimeMillis());
@@ -125,7 +125,7 @@ public class FilePrinter implements Printer {
         if (writer.isOpened()) {
           writer.close();
         }
-        checkFileClean();
+        cleanLogFilesIfNecessary();
         if (!writer.open(newFileName)) {
           return;
         }
@@ -151,9 +151,9 @@ public class FilePrinter implements Printer {
   }
 
   /**
-   * Check weather file should be clean
+   * Clean log files if should clean follow strategy
    */
-  void checkFileClean() {
+  private void cleanLogFilesIfNecessary() {
     File logDir = new File(folderPath);
     File[] files = logDir.listFiles();
     for (File file : files) {

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/CleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/CleanStrategy.java
@@ -1,0 +1,17 @@
+package com.elvishew.xlog.printer.file.clean;
+
+import java.io.File;
+
+/**
+ * Decide whether the log file should be clean.
+ */
+public interface CleanStrategy {
+
+  /**
+   * Whether we should clean a specified log file.
+   *
+   * @param file the log file
+   * @return true is we should clean the log file
+   */
+  boolean shouldClean(File file);
+}

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/FileLastModifiedCleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/FileLastModifiedCleanStrategy.java
@@ -5,7 +5,7 @@ import java.io.File;
 /**
  * Limit the file life of a max time.
  */
-public class TimeCleanStrategy implements CleanStrategy {
+public class FileLastModifiedCleanStrategy implements CleanStrategy {
 
   private long maxTimeMillis;
 
@@ -14,14 +14,14 @@ public class TimeCleanStrategy implements CleanStrategy {
    *
    * @param maxTimeMillis the max time the file can keep
    */
-  public TimeCleanStrategy(long maxTimeMillis) {
+  public FileLastModifiedCleanStrategy(long maxTimeMillis) {
     this.maxTimeMillis = maxTimeMillis;
   }
 
   @Override
   public boolean shouldClean(File file) {
     long currentTimeMillis = System.currentTimeMillis();
-    long fileTimeMillis = file.lastModified();
-    return (Math.abs(currentTimeMillis - fileTimeMillis) > maxTimeMillis);
+    long lastModified = file.lastModified();
+    return (currentTimeMillis - lastModified > maxTimeMillis);
   }
 }

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/NeverCleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/NeverCleanStrategy.java
@@ -1,0 +1,14 @@
+package com.elvishew.xlog.printer.file.clean;
+
+import java.io.File;
+
+/**
+ * Never Limit the file life.
+ */
+public class NeverCleanStrategy implements CleanStrategy {
+
+  @Override
+  public boolean shouldClean(File file) {
+    return false;
+  }
+}

--- a/library/src/main/java/com/elvishew/xlog/printer/file/clean/TimeCleanStrategy.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/clean/TimeCleanStrategy.java
@@ -1,0 +1,27 @@
+package com.elvishew.xlog.printer.file.clean;
+
+import java.io.File;
+
+/**
+ * Limit the file life of a max time.
+ */
+public class TimeCleanStrategy implements CleanStrategy {
+
+  private long maxTimeMillis;
+
+  /**
+   * Constructor.
+   *
+   * @param maxTimeMillis the max time the file can keep
+   */
+  public TimeCleanStrategy(long maxTimeMillis) {
+    this.maxTimeMillis = maxTimeMillis;
+  }
+
+  @Override
+  public boolean shouldClean(File file) {
+    long currentTimeMillis = System.currentTimeMillis();
+    long fileTimeMillis = file.lastModified();
+    return (Math.abs(currentTimeMillis - fileTimeMillis) > maxTimeMillis);
+  }
+}

--- a/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
+++ b/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
@@ -27,6 +27,8 @@ import com.elvishew.xlog.interceptor.BlacklistTagsFilterInterceptor;
 import com.elvishew.xlog.printer.AndroidPrinter;
 import com.elvishew.xlog.printer.Printer;
 import com.elvishew.xlog.printer.file.FilePrinter;
+import com.elvishew.xlog.printer.file.clean.NeverCleanStrategy;
+import com.elvishew.xlog.printer.file.clean.TimeCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.DateFileNameGenerator;
 
 import java.io.File;
@@ -34,6 +36,8 @@ import java.io.File;
 public class XLogSampleApplication extends Application {
 
   public static Printer globalFilePrinter;
+
+  private static final long MAX_TIME = 1000 * 60 * 60 * 24 * 2; // two days
 
   @Override
   public void onCreate() {
@@ -73,6 +77,7 @@ public class XLogSampleApplication extends Application {
         .Builder(new File(Environment.getExternalStorageDirectory(), "xlogsample").getPath())       // Specify the path to save log file
         .fileNameGenerator(new DateFileNameGenerator())        // Default: ChangelessFileNameGenerator("log")
         // .backupStrategy(new MyBackupStrategy())             // Default: FileSizeBackupStrategy(1024 * 1024)
+        .cleanStrategy(new TimeCleanStrategy(MAX_TIME))        // Default: NeverCleanStrategy()
         .logFlattener(new ClassicFlattener())                  // Default: DefaultFlattener
         .build();
 

--- a/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
+++ b/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
@@ -27,8 +27,6 @@ import com.elvishew.xlog.interceptor.BlacklistTagsFilterInterceptor;
 import com.elvishew.xlog.printer.AndroidPrinter;
 import com.elvishew.xlog.printer.Printer;
 import com.elvishew.xlog.printer.file.FilePrinter;
-import com.elvishew.xlog.printer.file.clean.NeverCleanStrategy;
-import com.elvishew.xlog.printer.file.clean.TimeCleanStrategy;
 import com.elvishew.xlog.printer.file.naming.DateFileNameGenerator;
 
 import java.io.File;
@@ -77,7 +75,7 @@ public class XLogSampleApplication extends Application {
         .Builder(new File(Environment.getExternalStorageDirectory(), "xlogsample").getPath())       // Specify the path to save log file
         .fileNameGenerator(new DateFileNameGenerator())        // Default: ChangelessFileNameGenerator("log")
         // .backupStrategy(new MyBackupStrategy())             // Default: FileSizeBackupStrategy(1024 * 1024)
-        // .cleanStrategy(new TimeCleanStrategy(MAX_TIME))     // Default: NeverCleanStrategy()
+        // .cleanStrategy(new FileLastModifiedCleanStrategy(MAX_TIME))     // Default: NeverCleanStrategy()
         .logFlattener(new ClassicFlattener())                  // Default: DefaultFlattener
         .build();
 

--- a/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
+++ b/sample/src/main/java/com/elvishew/xlogsample/XLogSampleApplication.java
@@ -77,7 +77,7 @@ public class XLogSampleApplication extends Application {
         .Builder(new File(Environment.getExternalStorageDirectory(), "xlogsample").getPath())       // Specify the path to save log file
         .fileNameGenerator(new DateFileNameGenerator())        // Default: ChangelessFileNameGenerator("log")
         // .backupStrategy(new MyBackupStrategy())             // Default: FileSizeBackupStrategy(1024 * 1024)
-        .cleanStrategy(new TimeCleanStrategy(MAX_TIME))        // Default: NeverCleanStrategy()
+        // .cleanStrategy(new TimeCleanStrategy(MAX_TIME))     // Default: NeverCleanStrategy()
         .logFlattener(new ClassicFlattener())                  // Default: DefaultFlattener
         .build();
 


### PR DESCRIPTION
When we chose DateFileNameGenerator, the files in log folder would be always increase day by day, so may be we need auto clean the old file feature to reduce the log files number in mobile device.