### PR TITLE
fix: Fix the NPE in FilePrinter and the problem if the log file not exist

### DIFF
--- a/library/src/main/java/com/elvishew/xlog/printer/file/FilePrinter.java
+++ b/library/src/main/java/com/elvishew/xlog/printer/file/FilePrinter.java
@@ -136,6 +136,12 @@ public class FilePrinter implements Printer {
     }
 
     File lastFile = writer.getFile();
+    
+    // fix the issue #77
+    if (!lastFile.exists()) {
+      writer.open(lastFile.getName());
+    }
+
     if (backupStrategy.shouldBackup(lastFile)) {
       // Backup the log file, and create a new log file.
       writer.close();
@@ -479,6 +485,11 @@ public class FilePrinter implements Printer {
      * @param flattenedLog the flattened log
      */
     void appendLog(String flattenedLog) {
+      // fix the npe , detail see issue #93
+      if (!isOpened()) {
+        return;
+      }
+
       try {
         bufferedWriter.write(flattenedLog);
         bufferedWriter.newLine();


### PR DESCRIPTION
- Fix the NPE in `FilePrinter.Writer`, detail see #93 
- Fix the problem if the log file not exist in `FilePrinter.doPrintln`, detail see #77 and thanks @vip110880 